### PR TITLE
Feature/#32 2주차: 초대코드 가입

### DIFF
--- a/src/main/java/com/uswproject/group/controller/GroupController.java
+++ b/src/main/java/com/uswproject/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package com.uswproject.group.controller;
 
 import com.uswproject.group.dto.request.GroupCreateRequest;
 import com.uswproject.group.dto.response.GroupDetailResponse;
+import com.uswproject.group.dto.response.GroupListResponse;
 import com.uswproject.group.entity.GroupEntity;
 import com.uswproject.group.service.GroupService;
 import org.springframework.web.bind.annotation.*;
@@ -36,7 +37,7 @@ public class GroupController {
 
     // 그룹 목록 조회
     @GetMapping
-    public List<GroupEntity> getGroups() {
+    public List<GroupListResponse> getGroups() {
         return groupService.getGroupList();
     }
 }

--- a/src/main/java/com/uswproject/group/controller/GroupController.java
+++ b/src/main/java/com/uswproject/group/controller/GroupController.java
@@ -1,7 +1,10 @@
 package com.uswproject.group.controller;
 
 import com.uswproject.group.dto.request.GroupCreateRequest;
+import com.uswproject.group.dto.request.GroupJoinRequest;
+import com.uswproject.group.dto.response.GroupCreateResponse;
 import com.uswproject.group.dto.response.GroupDetailResponse;
+import com.uswproject.group.dto.response.GroupJoinResponse;
 import com.uswproject.group.dto.response.GroupListResponse;
 import com.uswproject.group.entity.GroupEntity;
 import com.uswproject.group.service.GroupService;
@@ -20,8 +23,9 @@ public class GroupController {
     }
 
     // 그룹 생성
+    // 2주차: 생성 시 inviteCode 발급해서 같이 반환
     @PostMapping
-    public Long createGroup(@RequestBody GroupCreateRequest request) {
+    public GroupCreateResponse createGroup(@RequestBody GroupCreateRequest request) {
 
         return groupService.createGroup(
                 request.getName(),
@@ -39,5 +43,17 @@ public class GroupController {
     @GetMapping
     public List<GroupListResponse> getGroups() {
         return groupService.getGroupList();
+    }
+
+    /**
+     * 그룹 가입 API
+     * POST /groups/join
+     */
+    @PostMapping("/join")
+    public GroupJoinResponse joinGroup(@RequestBody GroupJoinRequest request) {
+        return groupService.joinGroup(
+                request.getInviteCode(),
+                request.getMemberId()
+        );
     }
 }

--- a/src/main/java/com/uswproject/group/controller/GroupController.java
+++ b/src/main/java/com/uswproject/group/controller/GroupController.java
@@ -1,0 +1,42 @@
+package com.uswproject.group.controller;
+
+import com.uswproject.group.dto.request.GroupCreateRequest;
+import com.uswproject.group.dto.response.GroupDetailResponse;
+import com.uswproject.group.entity.GroupEntity;
+import com.uswproject.group.service.GroupService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    public GroupController(GroupService groupService) {
+        this.groupService = groupService;
+    }
+
+    // 그룹 생성
+    @PostMapping
+    public Long createGroup(@RequestBody GroupCreateRequest request) {
+
+        return groupService.createGroup(
+                request.getName(),
+                request.getCreatorMemberId()
+        );
+    }
+
+    // 그룹 상세 조회
+    @GetMapping("/{groupId}")
+    public GroupDetailResponse getGroup(@PathVariable Long groupId) {
+        return groupService.getGroupDetail(groupId);
+    }
+
+    // 그룹 목록 조회
+    @GetMapping
+    public List<GroupEntity> getGroups() {
+        return groupService.getGroupList();
+    }
+}

--- a/src/main/java/com/uswproject/group/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/uswproject/group/dto/request/GroupCreateRequest.java
@@ -1,0 +1,24 @@
+package com.uswproject.group.dto.request;
+
+public class GroupCreateRequest {
+
+    private String name;
+    private Long creatorMemberId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getCreatorMemberId() {
+        return creatorMemberId;
+    }
+
+    public void setCreatorMemberId(Long creatorMemberId) {
+        this.creatorMemberId = creatorMemberId;
+    }
+
+}

--- a/src/main/java/com/uswproject/group/dto/request/GroupJoinRequest.java
+++ b/src/main/java/com/uswproject/group/dto/request/GroupJoinRequest.java
@@ -1,0 +1,19 @@
+package com.uswproject.group.dto.request;
+
+/**
+ * GroupJoinRequest (그룹 가입 요청 DTO)
+ *
+ * Postman 예시:
+ * {
+ *   "inviteCode": "ABCDEF12",
+ *   "memberId": 1
+ * }
+ */
+public class GroupJoinRequest {
+
+    private String inviteCode;
+    private Long memberId;
+
+    public String getInviteCode() { return inviteCode; }
+    public Long getMemberId() { return memberId; }
+}

--- a/src/main/java/com/uswproject/group/dto/response/GroupCreateResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupCreateResponse.java
@@ -1,7 +1,24 @@
 package com.uswproject.group.dto.response;
 
+import java.time.LocalDateTime;
 
+/**
+ * GroupCreateResponse (그룹 생성 응답 DTO)
+ * groupId + inviteCode를 같이 반환하도록 개선
+ */
 public class GroupCreateResponse {
 
+    private Long groupId;
+    private String inviteCode;
+    private LocalDateTime expiredAt; // (선택) 만료시간 보여주고 싶으면
 
+    public GroupCreateResponse(Long groupId, String inviteCode, LocalDateTime expiredAt) {
+        this.groupId = groupId;
+        this.inviteCode = inviteCode;
+        this.expiredAt = expiredAt;
+    }
+
+    public Long getGroupId() { return groupId; }
+    public String getInviteCode() { return inviteCode; }
+    public LocalDateTime getExpiredAt() { return expiredAt; }
 }

--- a/src/main/java/com/uswproject/group/dto/response/GroupCreateResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupCreateResponse.java
@@ -1,0 +1,7 @@
+package com.uswproject.group.dto.response;
+
+
+public class GroupCreateResponse {
+
+
+}

--- a/src/main/java/com/uswproject/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupDetailResponse.java
@@ -1,0 +1,26 @@
+package com.uswproject.group.dto.response;
+
+import java.util.List;
+
+public class GroupDetailResponse {
+
+    public Long groupId;
+    public String name;
+    public List<MemberInfo> members;
+
+    public GroupDetailResponse(Long groupId, String name, List<MemberInfo> members) {
+        this.groupId = groupId;
+        this.name = name;
+        this.members = members;
+    }
+
+    public static class MemberInfo {
+        public String name;
+        public String role;
+
+        public MemberInfo(String name, String role) {
+            this.name = name;
+            this.role = role;
+        }
+    }
+}

--- a/src/main/java/com/uswproject/group/dto/response/GroupJoinResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupJoinResponse.java
@@ -1,0 +1,32 @@
+package com.uswproject.group.dto.response;
+
+/**
+ * inviteCode로 그룹 가입 성공 시 응답 DTO
+ * - 어떤 그룹에 가입했는지 (groupId)
+ * - 어떤 멤버가 가입했는지 (memberId)
+ * - 가입된 역할이 무엇인지 (role)
+ */
+public class GroupJoinResponse {
+
+    private final Long groupId;
+    private final Long memberId;
+    private final String role;
+
+    public GroupJoinResponse(Long groupId, Long memberId, String role) {
+        this.groupId = groupId;
+        this.memberId = memberId;
+        this.role = role;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/com/uswproject/group/dto/response/GroupListResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupListResponse.java
@@ -2,6 +2,21 @@ package com.uswproject.group.dto.response;
 
 
 public class GroupListResponse {
+    private Long groupId;     // 그룹 PK
+    private String groupName; // 그룹 이름
 
+    public GroupListResponse() {}
 
+    public GroupListResponse(Long groupId, String groupName) {
+        this.groupId = groupId;
+        this.groupName = groupName;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
 }

--- a/src/main/java/com/uswproject/group/dto/response/GroupListResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupListResponse.java
@@ -1,0 +1,7 @@
+package com.uswproject.group.dto.response;
+
+
+public class GroupListResponse {
+
+
+}

--- a/src/main/java/com/uswproject/group/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/uswproject/group/dto/response/GroupMemberResponse.java
@@ -1,0 +1,7 @@
+package com.uswproject.group.dto.response;
+
+
+public class GroupMemberResponse {
+
+}
+

--- a/src/main/java/com/uswproject/group/entity/GroupEntity.java
+++ b/src/main/java/com/uswproject/group/entity/GroupEntity.java
@@ -1,0 +1,69 @@
+package com.uswproject.group.entity;
+
+import com.uswproject.member.entity.MemberEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+//@Entity
+//@Table(name = "groups")
+//public class GroupEntity {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//    // 그룹 PK
+//
+//    @Column(nullable = false)
+//    private String name;
+//    // 그룹 이름
+//
+//    @Enumerated(EnumType.STRING)
+//    private GroupStatus status;
+//    // 지금은 CREATED만 씀
+//
+//    private LocalDateTime createdAt;
+//    // 그룹 생성 시간
+//
+//    protected GroupEntity() {}
+//    // JPA가 객체 만들 때 필요
+//
+//    public GroupEntity(String name) {
+//        this.name = name;
+//        this.status = GroupStatus.CREATED;
+//        this.createdAt = LocalDateTime.now();
+//    }
+//
+//    // getter
+//    public Long getId() { return id; }
+//    public String getName() { return name; }
+//    public GroupStatus getStatus() { return status; }
+
+@Entity
+@Table(name = "groups")
+public class GroupEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    // 그룹 PK
+
+    @Column(nullable = false)
+    private String name;
+    // 그룹 이름
+
+    protected GroupEntity() {
+        // JPA 기본 생성자 (필수)
+    }
+
+    public GroupEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/uswproject/group/entity/GroupInviteCodeEntity.java
+++ b/src/main/java/com/uswproject/group/entity/GroupInviteCodeEntity.java
@@ -1,0 +1,62 @@
+package com.uswproject.group.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * GroupInviteCodeEntity (그룹 초대코드 엔티티)
+ * 핵심 요구사항:
+ * - inviteCode 하나로 여러 명 가입 가능
+ * - (선택) 만료(expiredAt) 넣을 수 있게 설계
+ */
+
+@Entity
+@Table(
+        name = "group_invite_codes",
+        uniqueConstraints = @UniqueConstraint(name = "uk_invite_code", columnNames = "invite_code")
+)
+public class GroupInviteCodeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private GroupEntity group; // 어떤 그룹의 초대코드인지
+
+    @Column(name = "invite_code", nullable = false, unique = true, length = 32)
+    private String inviteCode;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt; // 생성 시각
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt; // 만료 시각 (선택: null이면 만료 없음)
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive; // 활성/비활성
+
+    protected GroupInviteCodeEntity() {}
+
+    public GroupInviteCodeEntity(GroupEntity group, String inviteCode, LocalDateTime expiredAt) {
+        this.group = group;
+        this.inviteCode = inviteCode;
+        this.createdAt = LocalDateTime.now();
+        this.expiredAt = expiredAt;
+        this.isActive = true;
+    }
+
+    /** 만료 체크: expiredAt이 null이면 만료 없음으로 처리 */
+    public boolean isExpired() {
+        if (expiredAt == null) return false;
+        return expiredAt.isBefore(LocalDateTime.now());
+    }
+
+    public Long getId() { return id; }
+    public GroupEntity getGroup() { return group; }
+    public String getInviteCode() { return inviteCode; }
+    public LocalDateTime getExpiredAt() { return expiredAt; }
+    public boolean isActive() { return isActive; }
+}

--- a/src/main/java/com/uswproject/group/entity/GroupMemberEntity.java
+++ b/src/main/java/com/uswproject/group/entity/GroupMemberEntity.java
@@ -6,7 +6,13 @@ import java.time.LocalDateTime;
 import com.uswproject.member.entity.MemberEntity;
 
 @Entity
-@Table(name = "group_members")
+@Table(
+        name = "group_members",
+        // 유니크 제약 : 코드 실수호 중복 인서트 하려 해도 디비가 막아줌
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_group_member", columnNames = {"group_id", "member_id"})
+        }
+)
 public class GroupMemberEntity {
 
     @Id
@@ -40,6 +46,7 @@ public class GroupMemberEntity {
         this.joinedAt = LocalDateTime.now();
     }
 
+    public GroupEntity getGroup() { return group; }
     public MemberEntity getMember() { return member; }
     public GroupRole getRole() { return role; }
 }

--- a/src/main/java/com/uswproject/group/entity/GroupMemberEntity.java
+++ b/src/main/java/com/uswproject/group/entity/GroupMemberEntity.java
@@ -1,0 +1,45 @@
+package com.uswproject.group.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+import com.uswproject.member.entity.MemberEntity;
+
+@Entity
+@Table(name = "group_members")
+public class GroupMemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    // 중간테이블 PK
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false)
+    private GroupEntity group;
+    // 소속 그룹
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+    // 멤버
+
+    @Enumerated(EnumType.STRING)
+    private GroupRole role;
+    // LEADER / MEMBER
+
+    private LocalDateTime joinedAt;
+    // 그룹 참여 시각
+
+    protected GroupMemberEntity() {}
+
+    public GroupMemberEntity(GroupEntity group, MemberEntity member, GroupRole role) {
+        this.group = group;
+        this.member = member;
+        this.role = role;
+        this.joinedAt = LocalDateTime.now();
+    }
+
+    public MemberEntity getMember() { return member; }
+    public GroupRole getRole() { return role; }
+}

--- a/src/main/java/com/uswproject/group/entity/GroupMemberStatus.java
+++ b/src/main/java/com/uswproject/group/entity/GroupMemberStatus.java
@@ -1,0 +1,6 @@
+package com.uswproject.group.entity;
+
+public enum GroupMemberStatus {
+
+}
+

--- a/src/main/java/com/uswproject/group/entity/GroupRole.java
+++ b/src/main/java/com/uswproject/group/entity/GroupRole.java
@@ -1,0 +1,6 @@
+package com.uswproject.group.entity;
+
+public enum GroupRole {
+    LEADER,
+    MEMBER
+}

--- a/src/main/java/com/uswproject/group/entity/GroupStatus.java
+++ b/src/main/java/com/uswproject/group/entity/GroupStatus.java
@@ -1,0 +1,12 @@
+package com.uswproject.group.entity;
+
+public enum GroupStatus {
+    CREATED,
+    DISCUSSING,
+    LOCATION_FIXED,
+    WAITING,
+    FINISHED,
+    CANCELED
+}
+
+

--- a/src/main/java/com/uswproject/group/entity/GroupVisibility.java
+++ b/src/main/java/com/uswproject/group/entity/GroupVisibility.java
@@ -1,0 +1,5 @@
+package com.uswproject.group.entity;
+
+public enum GroupVisibility {
+
+}

--- a/src/main/java/com/uswproject/group/entity/MemberEntity
+++ b/src/main/java/com/uswproject/group/entity/MemberEntity
@@ -1,0 +1,28 @@
+## 멤버 패키지의 멤버엔티티와 겹쳐서 삭제함
+
+package com.uswproject.group.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "members")
+public class MemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    // 회원 PK
+
+    @Column(nullable = false)
+    private String name;
+    // 회원 이름
+
+    protected MemberEntity() {}
+
+    public MemberEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+}

--- a/src/main/java/com/uswproject/group/entity/TransportType.java
+++ b/src/main/java/com/uswproject/group/entity/TransportType.java
@@ -1,0 +1,5 @@
+package com.uswproject.group.entity;
+
+public enum TransportType {
+
+}

--- a/src/main/java/com/uswproject/group/repository/GroupInviteCodeRepository.java
+++ b/src/main/java/com/uswproject/group/repository/GroupInviteCodeRepository.java
@@ -1,0 +1,17 @@
+package com.uswproject.group.repository;
+
+import com.uswproject.group.entity.GroupInviteCodeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * GroupInviteCodeRepository (그룹 초대코드 레포지토리)
+ * - inviteCode로 조회/존재여부 확인이 핵심
+ */
+public interface GroupInviteCodeRepository extends JpaRepository<GroupInviteCodeEntity, Long> {
+
+    Optional<GroupInviteCodeEntity> findByInviteCode(String inviteCode);
+
+    boolean existsByInviteCode(String inviteCode);
+}

--- a/src/main/java/com/uswproject/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/uswproject/group/repository/GroupMemberRepository.java
@@ -1,0 +1,13 @@
+package com.uswproject.group.repository;
+
+import com.uswproject.group.entity.GroupMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupMemberRepository
+        extends JpaRepository<GroupMemberEntity, Long> {
+
+    List<GroupMemberEntity> findByGroupId(Long groupId);
+    // findByGroupId : 이 그룹에 속한 멤버 전부 가져오기
+}

--- a/src/main/java/com/uswproject/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/uswproject/group/repository/GroupMemberRepository.java
@@ -10,4 +10,7 @@ public interface GroupMemberRepository
 
     List<GroupMemberEntity> findByGroupId(Long groupId);
     // findByGroupId : 이 그룹에 속한 멤버 전부 가져오기
+
+    // 중복 가입 방지 핵심 메서드
+    boolean existsByGroupIdAndMemberId(Long groupId, Long memberId);
 }

--- a/src/main/java/com/uswproject/group/repository/GroupRepository.java
+++ b/src/main/java/com/uswproject/group/repository/GroupRepository.java
@@ -1,0 +1,8 @@
+package com.uswproject.group.repository;
+
+import com.uswproject.group.entity.GroupEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository
+        extends JpaRepository<GroupEntity, Long> {
+}

--- a/src/main/java/com/uswproject/group/repository/MemberRepository
+++ b/src/main/java/com/uswproject/group/repository/MemberRepository
@@ -1,0 +1,10 @@
+에러
+
+The bean 'memberRepository' ... could not be registered.
+A bean with that name has already been defined in
+
+com.uswproject.group.repository.MemberRepository
+com.uswproject.member.repository.MemberRepository
+
+-> 같은 이름의 Repository가 두 개 있음 (member패키지와 겹침)
+

--- a/src/main/java/com/uswproject/group/service/GroupService.java
+++ b/src/main/java/com/uswproject/group/service/GroupService.java
@@ -1,0 +1,98 @@
+package com.uswproject.group.service;
+
+import com.uswproject.group.dto.response.GroupDetailResponse;
+import com.uswproject.group.entity.*;
+import com.uswproject.group.repository.GroupMemberRepository;
+import com.uswproject.group.repository.GroupRepository;
+import com.uswproject.member.entity.MemberEntity;
+import com.uswproject.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class GroupService {
+
+    // 그룹 테이블 접근용
+    private final GroupRepository groupRepository;
+
+    // 그룹-회원 연결 테이블 접근용
+    private final GroupMemberRepository groupMemberRepository;
+
+    // 회원 테이블 접근용 (member 패키지)
+    private final MemberRepository memberRepository;
+
+    // 생성자 주입
+    public GroupService(GroupRepository groupRepository,
+                        GroupMemberRepository groupMemberRepository,
+                        MemberRepository memberRepository) {
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    /**
+     * 그룹 생성 API
+     * 1. 생성자(member)가 존재하는지 확인
+     * 2. 그룹 생성
+     * 3. 생성자를 LEADER로 GroupMember에 저장
+     */
+    @Transactional
+    public Long createGroup(String name, Long creatorId) {
+
+        // 그룹 생성자 조회
+        MemberEntity creator = memberRepository.findById(creatorId)
+                .orElseThrow(() -> new IllegalArgumentException("멤버 없음"));
+
+        // 그룹 생성
+        GroupEntity group = new GroupEntity(name);
+        groupRepository.save(group);
+
+        // 생성자를 LEADER로 그룹에 포함
+        GroupMemberEntity gm =
+                new GroupMemberEntity(group, creator, GroupRole.LEADER);
+
+        groupMemberRepository.save(gm);
+
+        return group.getId();
+    }
+
+    /**
+     * 그룹 상세 조회
+     * - 그룹 정보
+     * - 그룹에 속한 멤버 목록 + 역할
+     */
+    public GroupDetailResponse getGroupDetail(Long groupId) {
+
+        // 그룹 조회
+        GroupEntity group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("그룹 없음"));
+
+        // 해당 그룹에 속한 멤버들 조회
+        List<GroupMemberEntity> members =
+                groupMemberRepository.findByGroupId(groupId);
+
+        // 응답 DTO로 변환
+        List<GroupDetailResponse.MemberInfo> memberInfos =
+                members.stream()
+                        .map(gm -> new GroupDetailResponse.MemberInfo(
+                                gm.getMember().getName(),
+                                gm.getRole().name()
+                        ))
+                        .toList();
+
+        return new GroupDetailResponse(
+                group.getId(),
+                group.getName(),
+                memberInfos
+        );
+    }
+
+    /**
+     * 그룹 목록 조회
+     */
+    public List<GroupEntity> getGroupList() {
+        return groupRepository.findAll();
+    }
+}

--- a/src/main/java/com/uswproject/group/service/GroupService.java
+++ b/src/main/java/com/uswproject/group/service/GroupService.java
@@ -1,8 +1,11 @@
 package com.uswproject.group.service;
 
+import com.uswproject.group.dto.response.GroupCreateResponse;
 import com.uswproject.group.dto.response.GroupDetailResponse;
+import com.uswproject.group.dto.response.GroupJoinResponse;
 import com.uswproject.group.dto.response.GroupListResponse;
 import com.uswproject.group.entity.*;
+import com.uswproject.group.repository.GroupInviteCodeRepository;
 import com.uswproject.group.repository.GroupMemberRepository;
 import com.uswproject.group.repository.GroupRepository;
 import com.uswproject.member.entity.MemberEntity;
@@ -10,7 +13,9 @@ import com.uswproject.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class GroupService {
@@ -24,42 +29,122 @@ public class GroupService {
     // 회원 테이블 접근용 (member 패키지)
     private final MemberRepository memberRepository;
 
+    // 초대코드 테이블 접근용
+    private final GroupInviteCodeRepository groupInviteCodeRepository;
+
     // 생성자 주입
     public GroupService(GroupRepository groupRepository,
                         GroupMemberRepository groupMemberRepository,
+                        GroupInviteCodeRepository groupInviteCodeRepository,
                         MemberRepository memberRepository) {
         this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
+        this.groupInviteCodeRepository = groupInviteCodeRepository;
         this.memberRepository = memberRepository;
     }
 
     /**
+     * 1주차
      * 그룹 생성 API
      * 1. 생성자(member)가 존재하는지 확인
      * 2. 그룹 생성
      * 3. 생성자를 LEADER로 GroupMember에 저장
      */
-    @Transactional
-    public Long createGroup(String name, Long creatorId) {
 
-        // 그룹 생성자 조회
+    /**
+     * 2주차 반영: 그룹 생성 시 inviteCode 발급
+     * - group 생성
+     * - creator를 LEADER로 group_members에 저장
+     * - inviteCode 생성해서 group_invite_codes에 저장
+     */
+    @Transactional
+    public GroupCreateResponse createGroup(String name, Long creatorId) {
+
+        // 1) 생성자 멤버가 존재하는지 확인 (없으면 생성 불가)
         MemberEntity creator = memberRepository.findById(creatorId)
                 .orElseThrow(() -> new IllegalArgumentException("멤버 없음"));
 
-        // 그룹 생성
+        // 2) 그룹 생성 후 저장 (save해야 id가 생김)
         GroupEntity group = new GroupEntity(name);
         groupRepository.save(group);
 
-        // 생성자를 LEADER로 그룹에 포함
-        GroupMemberEntity gm =
-                new GroupMemberEntity(group, creator, GroupRole.LEADER);
-
+        // 3) 생성자를 그룹 멤버로 자동 포함 (LEADER)
+        GroupMemberEntity gm = new GroupMemberEntity(group, creator, GroupRole.LEADER);
         groupMemberRepository.save(gm);
 
-        return group.getId();
+        // 4) 초대코드 생성 (UUID 일부 사용 + 중복 방지)
+        String inviteCode = generateUniqueInviteCode();
+
+        // (선택) 만료 넣고 싶으면 expiredAt을 now+?? 로 설정
+        // 만료 기능은 선택이라 기본은 null(만료 없음)로 둠
+        LocalDateTime expiredAt = null;
+
+        // 5) 초대코드 저장
+        GroupInviteCodeEntity invite = new GroupInviteCodeEntity(group, inviteCode, expiredAt);
+        groupInviteCodeRepository.save(invite);
+
+        // 6) 응답: groupId + inviteCode + expiredAt
+        return new GroupCreateResponse(group.getId(), inviteCode, expiredAt);
     }
 
     /**
+     * 2주차
+     * 그룹 가입 API 로직
+     * - inviteCode로 그룹 찾기
+     * - (선택) 만료/비활성 체크
+     * - 중복 가입 방지
+     * - group_members에 MEMBER로 저장
+     * - 응답에 groupId, memberId, role 내려주기
+     */
+    @Transactional
+    public GroupJoinResponse joinGroup(String inviteCode, Long memberId) {
+
+        // 1) 초대코드로 초대코드 엔티티 조회
+        GroupInviteCodeEntity invite = groupInviteCodeRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 초대코드"));
+
+        // 2) (선택) 만료 체크
+        // expiredAt이 null이면 만료 없음 처리 (entity의 isExpired())
+        if (invite.isExpired()) {
+            throw new IllegalArgumentException("만료된 초대코드");
+        }
+
+        // 3) (선택) 비활성 체크
+        if (!invite.isActive()) {
+            throw new IllegalArgumentException("비활성화된 초대코드");
+        }
+
+        // 4) 가입할 멤버 조회
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("멤버 없음"));
+
+        // 5) 어느 그룹인지 가져오기
+        GroupEntity group = invite.getGroup();
+        Long groupId = group.getId();
+
+        // 6) 중복 가입 방지
+        boolean alreadyJoined = groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId);
+        if (alreadyJoined) {
+            throw new IllegalArgumentException("이미 가입된 멤버입니다.");
+        }
+
+        // 7) 중복 아니면 group_members에 저장 (기본 역할 MEMBER)
+        GroupMemberEntity gm = new GroupMemberEntity(group, member, GroupRole.MEMBER);
+        GroupMemberEntity saved = groupMemberRepository.save(gm);
+
+        // 8) 성공 응답 (groupId + memberId + role)
+        Long savedMemberId = saved.getMember().getId();
+
+        return new GroupJoinResponse(
+                saved.getGroup().getId(),
+                //savedMemberId,
+                saved.getMember().getId(),
+                saved.getRole().name()
+        );
+    }
+
+    /**
+     * 1주차
      * 그룹 상세 조회
      * - 그룹 정보
      * - 그룹에 속한 멤버 목록 + 역할
@@ -91,18 +176,33 @@ public class GroupService {
     }
 
     /**
+     * 1주차
      * 그룹 목록 조회
      * id, name만 DTO로 변환해 반환
      */
-
     public List<GroupListResponse> getGroupList() {
-        List<GroupEntity> groups = groupRepository.findAll();
-
-        return groups.stream()
+        return groupRepository.findAll().stream()
                 .map(g -> new GroupListResponse(
                         g.getId(),
                         g.getName()
                 ))
                 .toList();
+    }
+
+    /**
+     * UUID 일부로 초대코드 생성 + 중복 방지
+     */
+    private String generateUniqueInviteCode() {
+        while (true) {
+            // 예: "a1b2c3d4..." 형태에서 앞 8자리만 사용
+            String code = UUID.randomUUID().toString().replace("-", "")
+                    .substring(0, 8)
+                    .toUpperCase();
+
+            // 이미 존재하면 다시 뽑기
+            if (!groupInviteCodeRepository.existsByInviteCode(code)) {
+                return code;
+            }
+        }
     }
 }

--- a/src/main/java/com/uswproject/group/service/GroupService.java
+++ b/src/main/java/com/uswproject/group/service/GroupService.java
@@ -1,6 +1,7 @@
 package com.uswproject.group.service;
 
 import com.uswproject.group.dto.response.GroupDetailResponse;
+import com.uswproject.group.dto.response.GroupListResponse;
 import com.uswproject.group.entity.*;
 import com.uswproject.group.repository.GroupMemberRepository;
 import com.uswproject.group.repository.GroupRepository;
@@ -91,8 +92,17 @@ public class GroupService {
 
     /**
      * 그룹 목록 조회
+     * id, name만 DTO로 변환해 반환
      */
-    public List<GroupEntity> getGroupList() {
-        return groupRepository.findAll();
+
+    public List<GroupListResponse> getGroupList() {
+        List<GroupEntity> groups = groupRepository.findAll();
+
+        return groups.stream()
+                .map(g -> new GroupListResponse(
+                        g.getId(),
+                        g.getName()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/uswproject/member/entity/MemberEntity.java
+++ b/src/main/java/com/uswproject/member/entity/MemberEntity.java
@@ -15,7 +15,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Member extends BaseEntity {
+@Table(name = "member")
+public class MemberEntity extends BaseEntity {
 
     /**
      * @Id(PK)
@@ -40,7 +41,7 @@ public class Member extends BaseEntity {
      * 생성자를 private로 닫아 외부에서 new Member()를 통한 생성 금지
      * (ID는 DB에서 만들어주기에 제외)
      */
-    private Member(String email, String name, String password) {
+    private MemberEntity(String email, String name, String password) {
         this.email = email;
         this.name = name;
         this.password = password;
@@ -50,8 +51,8 @@ public class Member extends BaseEntity {
      * 정적 팩토리 메서드
      * 외부에서는 오직 이 메서드를 통해서만 객체 생성이 가능하다.
      */
-    public static Member create(String email, String name, String password) {
-        return new Member(email, name, password);
+    public static MemberEntity create(String email, String name, String password) {
+        return new MemberEntity(email, name, password);
     }
 
 }

--- a/src/main/java/com/uswproject/member/repository/MemberRepository.java
+++ b/src/main/java/com/uswproject/member/repository/MemberRepository.java
@@ -1,9 +1,9 @@
 package com.uswproject.member.repository;
 
-import com.uswproject.member.entity.Member;
+import com.uswproject.member.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,46 +7,31 @@ server:
 api:
   version: v1
 
-#spring:
-#  config:
-#    import: optional:file:./.env[.properties]
-#  datasource:
-#    driver-class-name: org.postgresql.Driver
-#    url: ${POSTGRES_DATABASE_URL}
-#    username: ${POSTGRES_USERNAME}
-#    password: ${POSTGRES_PASSWORD}
-#    hikari:
-#      maximum-pool-size: 50
-#      minimum-idle: 10
-#      idle-timeout: 300000
-#      connection-timeout: 30000
-#      max-lifetime: 1200000
-#  jpa:
-#    hibernate:
-#      ddl-auto: update
-#    properties:
-#      hibernate:
-#        default_batch_fetch_size: 500
-#        format_sql: true
-#        use_sql_comments: true
-#    open-in-view: false
-#    show-sql: false
-
 spring:
+  config:
+    import: optional:file:./.env[.properties]
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password: lhi916030@
-
+    url: ${POSTGRES_DATABASE_URL}
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 10
+      idle-timeout: 300000
+      connection-timeout: 30000
+      max-lifetime: 1200000
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
     properties:
       hibernate:
+        default_batch_fetch_size: 500
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+        use_sql_comments: true
+    open-in-view: false
+    show-sql: false
+
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,29 +7,47 @@ server:
 api:
   version: v1
 
+#spring:
+#  config:
+#    import: optional:file:./.env[.properties]
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: ${POSTGRES_DATABASE_URL}
+#    username: ${POSTGRES_USERNAME}
+#    password: ${POSTGRES_PASSWORD}
+#    hikari:
+#      maximum-pool-size: 50
+#      minimum-idle: 10
+#      idle-timeout: 300000
+#      connection-timeout: 30000
+#      max-lifetime: 1200000
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    properties:
+#      hibernate:
+#        default_batch_fetch_size: 500
+#        format_sql: true
+#        use_sql_comments: true
+#    open-in-view: false
+#    show-sql: false
+
 spring:
-  config:
-    import: optional:file:./.env[.properties]
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: ${POSTGRES_DATABASE_URL}
-    username: ${POSTGRES_USERNAME}
-    password: ${POSTGRES_PASSWORD}
-    hikari:
-      maximum-pool-size: 50
-      minimum-idle: 10
-      idle-timeout: 300000
-      connection-timeout: 30000
-      max-lifetime: 1200000
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: lhi916030@
+
   jpa:
     hibernate:
       ddl-auto: update
+    show-sql: true
     properties:
       hibernate:
-        default_batch_fetch_size: 500
         format_sql: true
-        use_sql_comments: true
-    open-in-view: false
-    show-sql: false
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+
 
 


### PR DESCRIPTION
## 📌 개요

그룹 초대코드를 통한 멤버 가입 기능 구현



## 🛠️ 작업 내용

- [x] Group 생성 시 inviteCode 발급(UUID 일부)
- [x] POST /groups/join (inviteCode로 가입)
- [x] 중복 가입 방지
- [x] 실패 케이스: 코드 없음/만료
 
* 코드는 다 짰는데 중복 가입 방지, 실패 케이스  테스트에서 막혔습니다.

## 📌 테스트 
<img width="1512" height="982" alt="멤버테이블_(가입 가능한)멤버 2명" src="https://github.com/user-attachments/assets/70f93ae1-92fb-44b5-969b-12dc42050261" />
멤버테이블

<img width="1512" height="982" alt="그룹테이블_그룹 1개" src="https://github.com/user-attachments/assets/0511f767-b08e-407f-b334-3e64f13b9e31" />
그룹테이블

<img width="1512" height="982" alt="그룹멤버테이블_멤버 가입 전" src="https://github.com/user-attachments/assets/1879ddf5-0285-40af-8645-a790c6814f15" />
그룹멤버테이블 : 멤버 가입 전. 아직 리더인 멤버1만 가입한 상태(리더는 자동 가입)

<img width="1512" height="982" alt="inviteCode 발급" src="https://github.com/user-attachments/assets/0e4699c4-4c7e-4488-b249-ef9ad7a52d9e" />
inviteCode 발급

<img width="1512" height="982" alt="inviteCode로 가입" src="https://github.com/user-attachments/assets/dbb173f8-9120-4768-a49f-724c661f2f80" />
inviteCode로 가입

<img width="1512" height="982" alt="만료 테스트 그룹" src="https://github.com/user-attachments/assets/2d4d6a34-e9d1-4dc4-9acc-5a6a084933ab" />
만료 테스트 그룹

<img width="656" height="223" alt="스크린샷 2026-02-25 오전 7 35 12" src="https://github.com/user-attachments/assets/1b28c0d3-1c14-488c-b7cf-bf8a81f96a43" />
여기서부터 막혔습니다


## 📌 차후 계획 (Optional)

* 중복 가입 방지, 실패 케이스 테스트 


### 📌 기타 참고 사항
📌 30번 브랜치에서 32번 작업을 계속해버림. 통으로 32번으로 옮김

